### PR TITLE
Fix tensorflow version to v2.11.1

### DIFF
--- a/chapter4/requirements.txt
+++ b/chapter4/requirements.txt
@@ -2,7 +2,7 @@ timm
 opencv-python
 albumentations
 pandas
-tensorflow
+tensorflow==2.11.1
 tf-slim
 faiss-gpu
 matplotlib


### PR DESCRIPTION
https://github.com/smly/kaggle-book-gokui/issues/28 で報告にあるように新しいバージョンの Tensorflow では依存ライブラリのバージョン整合性が合わない問題があるため v2.11.1 に固定する